### PR TITLE
Simplified + more compatible + more seamless CalcView/CalcViewModelView hooks

### DIFF
--- a/lua/autorun/sh_detours.lua
+++ b/lua/autorun/sh_detours.lua
@@ -70,7 +70,7 @@ if SERVER then return end
 hook.Add("EntityEmitSound", "seamless_portals_detour_sound", function(t)
 	if !SeamlessPortals or SeamlessPortals.PortalIndex < 1 then return end
 	for k, v in ipairs(ents.FindByClass("seamless_portal")) do
-		local exitportal = v:GetExitPortal()
+		local exitportal = v.GetExitPortal and v:GetExitPortal()
 		if !v.ExitPortal or !exitportal or !exitportal:IsValid() or !exitportal.GetExitSize then continue end
 		if !t.Pos or !t.Entity or t.Entity == NULL then continue end
 		if t.Pos:DistToSqr(v:GetPos()) < 50000 * exitportal:GetExitSize()[1] and (t.Pos - v:GetPos()):Dot(v:GetUp()) > 0 then

--- a/lua/autorun/sh_portal_movement.lua
+++ b/lua/autorun/sh_portal_movement.lua
@@ -35,26 +35,12 @@ local function updateCalcViews(finalPos, finalVel)
 			finalPos = ply:EyePos()
 			SeamlessPortals.DrawPlayerInView = false
 		end
-		
-		local wep = ply:GetActiveWeapon()
-		if wep:IsValid() and isfunction(wep.CalcView) then
-			local origin, angles, fov = wep:CalcView(ply, Vector(finalPos), Angle(angle), fov)
-			finalPos = origin
-			angle = angles
-		end
-
-		return {origin = finalPos, angles = angle}
+		origin = finalPos
 	end)
 
     -- weapons sometimes glitch out a bit when you teleport, since the weapon angle is wrong
 	hook.Add("CalcViewModelView", "seamless_portals_fix", function(wep, vm, oldPos, oldAng, pos, ang)
-		if wep:IsValid() and isfunction(wep.CalcViewModelView) then
-			local _pos, _ang = wep:CalcViewModelView(vm, Vector(oldPos), Angle(oldAng), Vector(pos), Angle(ang))
-			finalPos = _pos
-			ang = _ang
-		end
 		ang.r = ang.r * addAngle
-		return finalPos, ang
 	end)
 
     -- finish eyeangle lerp

--- a/lua/autorun/sh_portal_movement.lua
+++ b/lua/autorun/sh_portal_movement.lua
@@ -21,31 +21,33 @@ local function updateCalcViews(finalPos, finalVel)
 	timer.Remove("portals_eye_fix_delay")	--just in case you enter the portal while the timer is running
 	
 	local addAngle = 1
+	local wPos = Vector()
 	finalPos = finalPos - finalVel * FrameTime()	-- why does this work? idk but it feels nice, could be a source prediction thing
 	hook.Add("CalcView", "seamless_portals_fix", function(ply, origin, angle, fov)
-		if ply:EyePos():DistToSqr(origin) > 10000 then return end
+		local ePos = ply:EyePos()
+		if ePos:DistToSqr(origin) > 10000 then return end
 		addAngle = addAngle * 0.9
 		angle.r = angle.r * addAngle
 
-		-- position ping compensation
+		-- position ping compensation -- using real velocity for getting the actual feeling of the player position rather than guessing
 		if freezePly and ply:Ping() > 5 then
 			finalPos = finalPos + finalVel * FrameTime()
             SeamlessPortals.DrawPlayerInView = true
 		else
-			finalPos = ply:GetPos() + ply:GetCurrentViewOffset()
+			finalPos = ePos
 			SeamlessPortals.DrawPlayerInView = false
 		end
 		origin.x = finalPos.x
 		origin.y = finalPos.y
 		origin.z = finalPos.z
-		finalPos = origin
+		wPos = origin
 	end)
 
     -- weapons sometimes glitch out a bit when you teleport, since the weapon angle is wrong
 	hook.Add("CalcViewModelView", "seamless_portals_fix", function(wep, vm, oldPos, oldAng, pos, ang)
-		pos.x = pos.x + (finalPos.x - pos.x)
-		pos.y = pos.y + (finalPos.y - pos.y)
-		pos.z = pos.z + (finalPos.z - pos.z)
+		pos.x = pos.x + (wPos.x - pos.x)
+		pos.y = pos.y + (wPos.y - pos.y)
+		pos.z = pos.z + (wPos.z - pos.z)
 		ang.r = ang.r * addAngle
 	end)
 

--- a/lua/autorun/sh_portal_movement.lua
+++ b/lua/autorun/sh_portal_movement.lua
@@ -32,14 +32,20 @@ local function updateCalcViews(finalPos, finalVel)
 			finalPos = finalPos + finalVel * FrameTime()
             SeamlessPortals.DrawPlayerInView = true
 		else
-			finalPos = ply:EyePos()
+			finalPos = ply:GetPos() + ply:GetCurrentViewOffset()
 			SeamlessPortals.DrawPlayerInView = false
 		end
-		origin = finalPos
+		origin.x = finalPos.x
+		origin.y = finalPos.y
+		origin.z = finalPos.z
+		finalPos = origin
 	end)
 
     -- weapons sometimes glitch out a bit when you teleport, since the weapon angle is wrong
 	hook.Add("CalcViewModelView", "seamless_portals_fix", function(wep, vm, oldPos, oldAng, pos, ang)
+		pos.x = pos.x + (finalPos.x - pos.x)
+		pos.y = pos.y + (finalPos.y - pos.y)
+		pos.z = pos.z + (finalPos.z - pos.z)
 		ang.r = ang.r * addAngle
 	end)
 


### PR DESCRIPTION
This fixes most of the jitters and stutters with viewmodels and calcview hooks by modifying the values passed to the hook instead of returning a new table (preventing further hooks), and not impeding on weapons' hooks either.

https://github.com/user-attachments/assets/7c71fb60-a340-425c-91e4-d526fd36cdf7

Any funny stuff visible in the video is because of the weapons inherent properties with solid walls.

Oh yeah and added a sanity check for uninitiated exit portals.